### PR TITLE
Updates for up to Unraid 7.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@
 2. Open the Theme Engine settings, from the Unraid Settings page
 3. Toggle from `Basic view` to `Advanced view`
 4. Set `Enable custom styling` to `Yes`
-5. Copy and paste the code from [custom.css](./custom.css) into the `Custom styling (advanced)` field
+5. Copy and paste the following code into the `Custom styling (advanced)` field:
+```html
+</style>
+<link type="text/css" rel="Stylesheet" href="https://raw.githubusercontent.com/dohnutt/unraid-gui-responsive/refs/heads/main/custom.css" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+```
 6. Click apply
 7. Enjoy from your phone/tablet
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 5. Copy and paste the following code into the `Custom styling (advanced)` field:
 ```html
 </style>
-<link type="text/css" rel="Stylesheet" href="https://raw.githubusercontent.com/dohnutt/unraid-gui-responsive/refs/heads/main/custom.css" />
+<link type="text/css" rel="Stylesheet" href="https://rawcdn.githack.com/dohnutt/unraid-gui-responsive/refs/heads/main/custom.css" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 ```
 6. Click apply

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 5. Copy and paste the following code into the `Custom styling (advanced)` field:
 ```html
 </style>
-<link type="text/css" rel="Stylesheet" href="https://rawcdn.githack.com/dohnutt/unraid-gui-responsive/refs/heads/main/custom.css" />
+<link type="text/css" rel="Stylesheet" href="https://rawcdn.githack.com/ccmoris/unraid-gui-responsive/refs/heads/main/custom.css" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 ```
 6. Click apply

--- a/custom.css
+++ b/custom.css
@@ -77,6 +77,7 @@
     table.samba_mounts,
     table.usb_absent,
     table.local_usb,
+    table.tablesorter.shift,
     table.dashboard > tbody,
     div.title.disable_diskio,
     div.title.ud {

--- a/custom.css
+++ b/custom.css
@@ -67,8 +67,17 @@
     table.tablesorter.shift {
         margin: 0;
     }
-    table.share_status {
-        white-space: normal;
+    
+    table.disk_status,
+    table.share_status,
+    table.plugins,
+    table#docker_containers,
+    table#kvm_table,
+    table.dashboard > tbody {
+        max-width: 100%;
+        overflow-x: auto;
+        display: block;
+    }
     }
 }
 

--- a/custom.css
+++ b/custom.css
@@ -73,7 +73,13 @@
     table.plugins,
     table#docker_containers,
     table#kvm_table,
-    table.dashboard > tbody {
+    table.usb_mounts,
+    table.samba_mounts,
+    table.usb_absent,
+    table.local_usb,
+    table.dashboard > tbody,
+    div.title.disable_diskio,
+    div.title.ud {
         max-width: 100%;
         overflow-x: auto;
         display: block;

--- a/custom.css
+++ b/custom.css
@@ -1,6 +1,6 @@
 /**
  * https://github.com/ccmorris/unraid-gui-responsive
- * Last modified: 2024-03-24
+ * Last modified: 2025-02-26
 */
 
 @media (max-width: 1260px) {

--- a/custom.css
+++ b/custom.css
@@ -78,6 +78,9 @@
         overflow-x: auto;
         display: block;
     }
+
+    span.status.vhshift {
+        margin-right: 0;
     }
 }
 

--- a/custom.css
+++ b/custom.css
@@ -305,9 +305,3 @@
         column-count: 2;
     }
 }
-
-/**
- * NOTE: The /style and meta viewport tags are important!
-*/
-</style>
-<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/custom.css
+++ b/custom.css
@@ -8,6 +8,7 @@
         text-align: left;
     }
 
+    #displaybox,
     #template {
         min-width: auto;
         margin: 0;


### PR DESCRIPTION
In keeping with the spirit of the strategy as stated in the README, this PR attempts to fix the issues brought about by Unraid 7 in the least disruptive way possible.

As such, this fixes two main issues I came across:

1. viewport width issues where `#displaybox` is setting a min-width on the page.
2. rather than compressing tables into the viewport, it allows them to display at a larger size, with horizontal scrollbars to navigate them. It uses this method to do so: https://stackoverflow.com/questions/17770257/scrolling-tables-horizontally-without-wrapping-them-in-div

Admittedly, I hadn't used this repo in Unraid 6 — in fact I am a very new Unraid user, having only ever used version 7 — but I hope it falls in line with what you've done in the past. Thanks for getting the ball rolling, I hope this is helpful to you!

---

Two additional proposals, which could be broken out into other PRs:

1. I think it would be better to link to remote CSS rather than instruct the user to copy/paste the entire CSS contents into the Theme Engine CSS field. I'm using https://raw.githack.com to proxy the repo's CSS file so it's easy maintenance.

2. I noticed that tabs and their content are forced to display rather than just continuing to use them as-is. In my limited testing, the tabs worked perfectly fine for mobile but perhaps there was a reason for this. I left this code untouched but may adjust it in my own personal use.