### PR TITLE
Add table in Tools > Preclear Disk

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -79,6 +79,7 @@
     table.local_usb,
     table.tablesorter.shift,
     table.dashboard > tbody,
+    table.preclear,
     div.title.disable_diskio,
     div.title.ud {
         max-width: 100%;


### PR DESCRIPTION
Extending the scrollable table CSS introduced in #5 

Adds support for table in Tools > Preclear Disk, as part of the Unassigned Devices Preclear plugin